### PR TITLE
fix script freeze (scribus 1.7.0 linux AppImage)

### DIFF
--- a/PhotoBookTools/PhotoBookImageCropResize.py
+++ b/PhotoBookTools/PhotoBookImageCropResize.py
@@ -85,7 +85,7 @@ class ScPhotoBookImageCropResize:
             newHeight = int(frameSizeY * imageResolution)
             scribus.setUnit(UNIT_POINTS)
 
-            # Calculate cropping        
+            # Calculate cropping
             imageXOffset = scribus.getProperty(imageFrame,'imageXOffset')
             imageYOffset = scribus.getProperty(imageFrame,'imageYOffset')
             frameSizeX,frameSizeY = scribus.getSize(imageFrame)
@@ -165,10 +165,11 @@ class ScPhotoBookImageCropResize:
                 scribus.progressSet(i)
                 obj = getSelectedObject(i)
                 selectionList.append(obj)
-                if (getProperty(obj, 'itemType')) == 12:
+                objectType = getObjectType(obj)
+                if objectType == 'Group':
                     messageBox('Warning', 'Grouped items will be skipped.\nPlease ungroup "'
                         +obj+'" and try again.', ICON_WARNING)
-                elif (getObjectType(obj) == 'ImageFrame') and (getImageFile(obj) != ""):
+                elif (objectType == 'ImageFrame') and (getImageFile(obj) != ""):
                     self.handleImage(obj)
                 else: # not an image frame -> skip
                     pass

--- a/PhotoBookTools/PhotoBookLayoutMaker.py
+++ b/PhotoBookTools/PhotoBookLayoutMaker.py
@@ -114,7 +114,7 @@ class ScPhotoBookLayoutMaker:
             for i in range (0, nbrSelected):
                 obj = getSelectedObject(i)
                 selectionList.append(obj)
-                if (getProperty(obj, 'itemType')) == 12:
+                if getObjectType(obj) == 'Group':
                     messageBox('Warning', 'Grouped items are not allowed as source.\nPlease ungroup "'
                         +obj+'" and try again.', ICON_CRITICAL)
                     sys.exit(1)


### PR DESCRIPTION
Scripts freeze when getting object type property (using scribus 1.7.0 as AppImage on Linux).